### PR TITLE
Make Tab insert (partial) completion instead of select next menu item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reedline"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["The Nushell Project Developers", "JT <jonathan.d.turner@gmail.com>"]
 edition = "2021"
 description = "A readline-like crate for CLI text input"

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Reedline::create().with_highlighter(Box::new(ExampleHighlighter::new(commands)))
 ```rust
 // Create a reedline object with tab completions support
 
-use reedline::{ColumnarMenu, DefaultCompleter, Reedline, ReedlineMenu};
+use reedline::{default_emacs_keybindings, ColumnarMenu, DefaultCompleter, Emacs, KeyCode, KeyModifiers, Reedline, ReedlineEvent, ReedlineMenu};
 
 let commands = vec![
   "test".into(),
@@ -131,9 +131,23 @@ let commands = vec![
 let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 // Use the interactive menu to select options from the completer
 let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
+// Set up the required keybindings
+let mut keybindings = default_emacs_keybindings();
+keybindings.add_binding(
+    KeyModifiers::NONE,
+    KeyCode::Tab,
+    ReedlineEvent::UntilFound(vec![
+        ReedlineEvent::Menu("completion_menu".to_string()),
+        ReedlineEvent::MenuNext,
+    ]),
+);
 
-let mut line_editor =
-Reedline::create().with_completer(completer).with_menu(ReedlineMenu::EngineCompleter(completion_menu));
+let edit_mode = Box::new(Emacs::new(keybindings));
+
+let mut line_editor = Reedline::create()
+    .with_completer(completer)
+    .with_menu(ReedlineMenu::EngineCompleter(completion_menu))
+    .with_edit_mode(edit_mode);
 ```
 
 ### Integrate with `Hinter` for fish-style history autosuggestions

--- a/README.md
+++ b/README.md
@@ -37,22 +37,22 @@ For the full documentation visit <https://docs.rs/reedline>. The examples should
 // Create a default reedline object to handle user input
 
 use reedline::{DefaultPrompt, Reedline, Signal};
-use std::io;
 
-fn main() -> io::Result<()> {
-    let mut line_editor = Reedline::create()?;
-    let prompt = DefaultPrompt::default();
+let mut line_editor = Reedline::create();
+let prompt = DefaultPrompt::default();
 
-    loop {
-        let sig = line_editor.read_line(&prompt)?;
-        match sig {
-            Signal::Success(buffer) => {
-                println!("We processed: {}", buffer);
-            }
-            Signal::CtrlD | Signal::CtrlC => {
-                println!("\nAborted!");
-                break Ok(());
-            }
+loop {
+    let sig = line_editor.read_line(&prompt);
+    match sig {
+        Ok(Signal::Success(buffer)) => {
+            println!("We processed: {}", buffer);
+        }
+        Ok(Signal::CtrlD) | Ok(Signal::CtrlC) => {
+            println!("\nAborted!");
+            break;
+        }
+        x => {
+            println!("Event: {:?}", x);
         }
     }
 }
@@ -64,22 +64,23 @@ fn main() -> io::Result<()> {
 // Configure reedline with custom keybindings
 
 //Cargo.toml
-//  [dependencies]
-//  crossterm = "*"
+//    [dependencies]
+//    crossterm = "*"
 
 use {
   crossterm::event::{KeyCode, KeyModifiers},
-  reedline::{default_emacs_keybindings, EditCommand, Reedline},
+  reedline::{default_emacs_keybindings, EditCommand, Reedline, Emacs, ReedlineEvent},
 };
 
 let mut keybindings = default_emacs_keybindings();
 keybindings.add_binding(
-  KeyModifiers::ALT,
-  KeyCode::Char('m'),
-  vec![EditCommand::BackspaceWord],
+    KeyModifiers::ALT,
+    KeyCode::Char('m'),
+    ReedlineEvent::Edit(vec![EditCommand::BackspaceWord]),
 );
+let edit_mode = Box::new(Emacs::new(keybindings));
 
-let mut line_editor = Reedline::create().with_keybindings(keybindings);
+let mut line_editor = Reedline::create().with_edit_mode(edit_mode);
 ```
 
 ### Integrate with `History`

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,26 @@
+// Create a default reedline object to handle user input
+// cargo run --example basic
+//
+// You can browse the local (non persistent) history using Up/Down or Ctrl n/p.
+
+use reedline::{DefaultPrompt, Reedline, Signal};
+use std::io;
+
+fn main() -> io::Result<()> {
+    // Create a new Reedline engine with a local History that is not synchronized to a file.
+    let mut line_editor = Reedline::create();
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {}", buffer);
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/examples/completions.rs
+++ b/examples/completions.rs
@@ -27,7 +27,7 @@ fn main() -> io::Result<()> {
         "hello world reedline".into(),
         "this is the reedline crate".into(),
     ];
-    let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
+    let completer = Box::new(DefaultCompleter::new_with_wordlen(commands, 2));
     // Use the interactive menu to select options from the completer
     let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
 

--- a/examples/completions.rs
+++ b/examples/completions.rs
@@ -1,0 +1,58 @@
+// Create a reedline object with tab completions support
+// cargo run --example completions
+//
+// "t" [Tab] will allow you to select the completions "test" and "this is the reedline crate"
+// [Enter] to select the chosen alternative
+
+use reedline::{
+    default_emacs_keybindings, ColumnarMenu, DefaultCompleter, DefaultPrompt, Emacs, KeyCode,
+    KeyModifiers, Keybindings, Reedline, ReedlineEvent, ReedlineMenu, Signal,
+};
+use std::io;
+
+fn add_menu_keybindings(keybindings: &mut Keybindings) {
+    keybindings.add_binding(
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::Menu("completion_menu".to_string()),
+            ReedlineEvent::MenuNext,
+        ]),
+    );
+}
+fn main() -> io::Result<()> {
+    let commands = vec![
+        "test".into(),
+        "hello world".into(),
+        "hello world reedline".into(),
+        "this is the reedline crate".into(),
+    ];
+    let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
+    // Use the interactive menu to select options from the completer
+    let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
+
+    let mut keybindings = default_emacs_keybindings();
+    add_menu_keybindings(&mut keybindings);
+
+    let edit_mode = Box::new(Emacs::new(keybindings));
+
+    let mut line_editor = Reedline::create()
+        .with_completer(completer)
+        .with_menu(ReedlineMenu::EngineCompleter(completion_menu))
+        .with_edit_mode(edit_mode);
+
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {}", buffer);
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/examples/highlighter.rs
+++ b/examples/highlighter.rs
@@ -1,0 +1,31 @@
+// Create a reedline object with highlighter support.
+// cargo run --example highlighter
+//
+// unmatched input is marked red, matched input is marked green
+use reedline::{DefaultPrompt, ExampleHighlighter, Reedline, Signal};
+use std::io;
+
+fn main() -> io::Result<()> {
+    let commands = vec![
+        "test".into(),
+        "hello world".into(),
+        "hello world reedline".into(),
+        "this is the reedline crate".into(),
+    ];
+    let mut line_editor =
+        Reedline::create().with_highlighter(Box::new(ExampleHighlighter::new(commands)));
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {}", buffer);
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/examples/hinter.rs
+++ b/examples/hinter.rs
@@ -1,0 +1,31 @@
+// Create a reedline object with in-line hint support.
+// cargo run --example hinter
+//
+// Fish-style history based hinting.
+// assuming history ["abc", "ade"]
+// pressing "a" hints to abc.
+// Up/Down or Ctrl p/n, to select next/previous match
+
+use nu_ansi_term::{Color, Style};
+use reedline::{DefaultHinter, DefaultPrompt, Reedline, Signal};
+use std::io;
+
+fn main() -> io::Result<()> {
+    let mut line_editor = Reedline::create().with_hinter(Box::new(
+        DefaultHinter::default().with_style(Style::new().italic().fg(Color::LightGray)),
+    ));
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {}", buffer);
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/examples/history.rs
+++ b/examples/history.rs
@@ -1,0 +1,33 @@
+// Create a reedline object with history support, including history size limits.
+// cargo run --example history
+//
+// A file `history.txt` will be created (or replaced).
+// Allows for persistent loading of previous session.
+//
+// Browse history by Up/Down arrows or Ctrl-n/p
+
+use reedline::{DefaultPrompt, FileBackedHistory, Reedline, Signal};
+use std::io;
+
+fn main() -> io::Result<()> {
+    let history = Box::new(
+        FileBackedHistory::with_file(5, "history.txt".into())
+            .expect("Error configuring history with file"),
+    );
+
+    let mut line_editor = Reedline::create().with_history(history);
+    let prompt = DefaultPrompt::default();
+
+    loop {
+        let sig = line_editor.read_line(&prompt)?;
+        match sig {
+            Signal::Success(buffer) => {
+                println!("We processed: {}", buffer);
+            }
+            Signal::CtrlD | Signal::CtrlC => {
+                println!("\nAborted!");
+                break Ok(());
+            }
+        }
+    }
+}

--- a/src/core_editor/editor.rs
+++ b/src/core_editor/editor.rs
@@ -55,6 +55,7 @@ impl Editor {
             EditCommand::MoveWordRightEnd => self.line_buffer.move_word_right_end(),
             EditCommand::MoveBigWordRightEnd => self.line_buffer.move_big_word_right_end(),
             EditCommand::InsertChar(c) => self.line_buffer.insert_char(*c),
+            EditCommand::Complete => {}
             EditCommand::InsertString(str) => self.line_buffer.insert_str(str),
             EditCommand::InsertNewline => self.line_buffer.insert_newline(),
             EditCommand::ReplaceChar(chr) => self.replace_char(*chr),

--- a/src/edit_mode/emacs.rs
+++ b/src/edit_mode/emacs.rs
@@ -22,6 +22,9 @@ pub fn default_emacs_keybindings() -> Keybindings {
     add_common_navigation_bindings(&mut kb);
     add_common_edit_bindings(&mut kb);
 
+    // This could be in common, but in Vi it also changes the mode
+    kb.add_binding(KM::NONE, KC::Enter, ReedlineEvent::Enter);
+
     // *** CTRL ***
     // Moves
     kb.add_binding(
@@ -141,7 +144,6 @@ impl EditMode for Emacs {
                             .unwrap_or(ReedlineEvent::None)
                     }
                 }
-                (KeyModifiers::NONE, KeyCode::Enter) => ReedlineEvent::Enter,
                 _ => self
                     .keybindings
                     .find_binding(modifiers, code)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -928,8 +928,20 @@ impl Reedline {
                                     self.completer.as_mut(),
                                     self.history.as_ref(),
                                 );
-                                if menu.get_values().len() == 1 {
-                                    return self.handle_editor_event(prompt, ReedlineEvent::Enter);
+                                if let Some(&EditCommand::Complete) = commands.first() {
+                                    if menu.get_values().len() == 1 {
+                                        return self
+                                            .handle_editor_event(prompt, ReedlineEvent::Enter);
+                                    } else if self.partial_completions
+                                        && menu.can_partially_complete(
+                                            self.quick_completions,
+                                            &mut self.editor,
+                                            self.completer.as_mut(),
+                                            self.history.as_ref(),
+                                        )
+                                    {
+                                        return Ok(EventStatus::Handled);
+                                    }
                                 }
                                 if self.editor.line_buffer().get_buffer().is_empty() {
                                     menu.menu_event(MenuEvent::Deactivate);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -915,25 +915,31 @@ impl Reedline {
                 self.run_edit_commands(&commands);
                 if let Some(menu) = self.menus.iter_mut().find(|men| men.is_active()) {
                     if self.quick_completions && menu.can_quick_complete() {
-                        menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                        menu.update_values(
-                            &mut self.editor,
-                            self.completer.as_mut(),
-                            self.history.as_ref(),
-                        );
-
-                        if menu.get_values().len() == 1 {
-                            return self.handle_editor_event(prompt, ReedlineEvent::Enter);
+                        match commands.first() {
+                            Some(&EditCommand::Backspace)
+                            | Some(&EditCommand::BackspaceWord)
+                            | Some(&EditCommand::MoveToLineStart) => {
+                                menu.menu_event(MenuEvent::Deactivate)
+                            }
+                            _ => {
+                                menu.menu_event(MenuEvent::Edit(self.quick_completions));
+                                menu.update_values(
+                                    &mut self.editor,
+                                    self.completer.as_mut(),
+                                    self.history.as_ref(),
+                                );
+                                if menu.get_values().len() == 1 {
+                                    return self.handle_editor_event(prompt, ReedlineEvent::Enter);
+                                }
+                                if self.editor.line_buffer().get_buffer().is_empty() {
+                                    menu.menu_event(MenuEvent::Deactivate);
+                                } else {
+                                    menu.menu_event(MenuEvent::Edit(self.quick_completions));
+                                }
+                            }
                         }
                     }
-
-                    if self.editor.line_buffer().get_buffer().is_empty() {
-                        menu.menu_event(MenuEvent::Deactivate);
-                    } else {
-                        menu.menu_event(MenuEvent::Edit(self.quick_completions));
-                    }
                 }
-
                 Ok(EventStatus::Handled)
             }
             ReedlineEvent::OpenEditor => self.open_editor().map(|_| EventStatus::Handled),

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -99,6 +99,9 @@ pub enum EditCommand {
     /// Clear to the end of the current line
     ClearToLineEnd,
 
+    /// Insert completion: entire completion if there is only one possibility, or else up to shared prefix.
+    Complete,
+
     /// Cut the current line
     CutCurrentLine,
 
@@ -216,6 +219,7 @@ impl Display for EditCommand {
             EditCommand::DeleteWord => write!(f, "DeleteWord"),
             EditCommand::Clear => write!(f, "Clear"),
             EditCommand::ClearToLineEnd => write!(f, "ClearToLineEnd"),
+            EditCommand::Complete => write!(f, "Complete"),
             EditCommand::CutCurrentLine => write!(f, "CutCurrentLine"),
             EditCommand::CutFromStart => write!(f, "CutFromStart"),
             EditCommand::CutFromLineStart => write!(f, "CutFromLineStart"),
@@ -287,6 +291,7 @@ impl EditCommand {
             | EditCommand::DeleteWord
             | EditCommand::Clear
             | EditCommand::ClearToLineEnd
+            | EditCommand::Complete
             | EditCommand::CutCurrentLine
             | EditCommand::CutFromStart
             | EditCommand::CutFromLineStart

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -422,6 +422,12 @@ pub enum ReedlineEvent {
     /// Handle enter event
     Enter,
 
+    /// Handle unconditional submit event
+    Submit,
+
+    /// Submit at the end of the *complete* text, otherwise newline
+    SubmitOrNewline,
+
     /// Esc event
     Esc,
 
@@ -510,6 +516,8 @@ impl Display for ReedlineEvent {
             ReedlineEvent::ClearScreen => write!(f, "ClearScreen"),
             ReedlineEvent::ClearScrollback => write!(f, "ClearScrollback"),
             ReedlineEvent::Enter => write!(f, "Enter"),
+            ReedlineEvent::Submit => write!(f, "Submit"),
+            ReedlineEvent::SubmitOrNewline => write!(f, "SubmitOrNewline"),
             ReedlineEvent::Esc => write!(f, "Esc"),
             ReedlineEvent::Mouse => write!(f, "Mouse"),
             ReedlineEvent::Resize(_, _) => write!(f, "Resize <int> <int>"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,24 +15,24 @@
 //!
 //! use reedline::{DefaultPrompt, Reedline, Signal};
 //!
-//!  let mut line_editor = Reedline::create();
-//!  let prompt = DefaultPrompt::default();
+//! let mut line_editor = Reedline::create();
+//! let prompt = DefaultPrompt::default();
 //!
-//!  loop {
-//!      let sig = line_editor.read_line(&prompt);
-//!      match sig {
-//!          Ok(Signal::Success(buffer)) => {
-//!              println!("We processed: {}", buffer);
-//!          }
-//!          Ok(Signal::CtrlD) | Ok(Signal::CtrlC) => {
-//!              println!("\nAborted!");
-//!              break;
-//!          }
-//!          x => {
-//!              println!("Event: {:?}", x);
-//!          }
-//!      }
-//!  }
+//! loop {
+//!     let sig = line_editor.read_line(&prompt);
+//!     match sig {
+//!         Ok(Signal::Success(buffer)) => {
+//!             println!("We processed: {}", buffer);
+//!         }
+//!         Ok(Signal::CtrlD) | Ok(Signal::CtrlC) => {
+//!             println!("\nAborted!");
+//!             break;
+//!         }
+//!         x => {
+//!             println!("Event: {:?}", x);
+//!         }
+//!     }
+//! }
 //! ```
 //! ## Integrate with custom keybindings
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //! ```rust
 //! // Create a reedline object with tab completions support
 //!
-//! use reedline::{ColumnarMenu, DefaultCompleter, Reedline, ReedlineMenu};
+//! use reedline::{default_emacs_keybindings, ColumnarMenu, DefaultCompleter, Emacs, KeyCode, KeyModifiers, Reedline, ReedlineEvent, ReedlineMenu};
 //!
 //! let commands = vec![
 //!   "test".into(),
@@ -107,9 +107,23 @@
 //! let completer = Box::new(DefaultCompleter::new_with_wordlen(commands.clone(), 2));
 //! // Use the interactive menu to select options from the completer
 //! let completion_menu = Box::new(ColumnarMenu::default().with_name("completion_menu"));
+//! // Set up the required keybindings
+//! let mut keybindings = default_emacs_keybindings();
+//! keybindings.add_binding(
+//!     KeyModifiers::NONE,
+//!     KeyCode::Tab,
+//!     ReedlineEvent::UntilFound(vec![
+//!         ReedlineEvent::Menu("completion_menu".to_string()),
+//!         ReedlineEvent::MenuNext,
+//!     ]),
+//! );
 //!
-//! let mut line_editor =
-//! Reedline::create().with_completer(completer).with_menu(ReedlineMenu::EngineCompleter(completion_menu));
+//! let edit_mode = Box::new(Emacs::new(keybindings));
+//!
+//! let mut line_editor = Reedline::create()
+//!     .with_completer(completer)
+//!     .with_menu(ReedlineMenu::EngineCompleter(completion_menu))
+//!     .with_edit_mode(edit_mode);
 //! ```
 //!
 //! ## Integrate with [`Hinter`] for fish-style history autosuggestions

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         KeyCode::Tab,
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("completion_menu".to_string()),
-            ReedlineEvent::MenuNext,
+            ReedlineEvent::Edit(vec![EditCommand::Complete]),
         ]),
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use {
 };
 
 fn main() -> Result<()> {
+    println!("Ctrl-D to quit");
     // quick command like parameter handling
     let vi_mode = matches!(std::env::args().nth(1), Some(x) if x == "--vi");
     let args: Vec<String> = std::env::args().collect();


### PR DESCRIPTION
**This is not a PR against the public nushell project; just my personal fork**

This PR makes nushell tab completion behave more like zsh/bash. Assuming `quick_completions = true`:

- Changes Tab so that it completes instead of selecting the next menu item (arrow keys can be used for that)
- Completion is "as far as possible". So, the entire word if there's a unique completion, or else up to the shared prefix of possible completions.
- Gets rid of the quick completion behavior whereby a word was completed automatically as soon as the input came to have a unique completion.

See https://github.com/dandavison/nushell/pull/6 to use this with nushell.
